### PR TITLE
RMET-585 Firebase Dynamic Links Plugin - Only deal with the same dynamic link once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,5 +8,8 @@ The changes documented here do not include those from the original repository.
 
 ## [Unreleased]
 
+## 2021-05-03
+- fix: changed Android implementation of respondWithDynamicLink to only deal with the same dynamic link once (https://outsystemsrd.atlassian.net/browse/RMET-585)
+
 ## 2021-03-26
 - feature: added hooks to configure domain uri prefix for dynamic link (iOS and Android) (https://outsystemsrd.atlassian.net/browse/RMET-436) (https://outsystemsrd.atlassian.net/browse/RMET-455)

--- a/src/android/FirebaseDynamicLinksPlugin.java
+++ b/src/android/FirebaseDynamicLinksPlugin.java
@@ -31,6 +31,9 @@ import by.chemerisuk.cordova.support.ReflectiveCordovaPlugin;
 public class FirebaseDynamicLinksPlugin extends ReflectiveCordovaPlugin {
     private static final String TAG = "FirebaseDynamicLinks";
 
+    private static final int CALLER_ON_DYNAMIC_LINK = 1;
+    private static final int CALLER_GET_DYNAMIC_LINK = 2;
+
     private FirebaseDynamicLinks firebaseDynamicLinks;
     private String domainUriPrefix;
     private CallbackContext dynamicLinkCallback;
@@ -48,13 +51,13 @@ public class FirebaseDynamicLinksPlugin extends ReflectiveCordovaPlugin {
     @Override
     public void onNewIntent(Intent intent) {
         if (dynamicLinkCallback != null) {
-            respondWithDynamicLink(intent, dynamicLinkCallback, 1);
+            respondWithDynamicLink(intent, dynamicLinkCallback, CALLER_ON_DYNAMIC_LINK);
         }
     }
 
     @CordovaMethod
     private void getDynamicLink(CallbackContext callbackContext) {
-        respondWithDynamicLink(cordova.getActivity().getIntent(), callbackContext, 2);
+        respondWithDynamicLink(cordova.getActivity().getIntent(), callbackContext, CALLER_GET_DYNAMIC_LINK);
     }
 
     @CordovaMethod
@@ -103,7 +106,7 @@ public class FirebaseDynamicLinksPlugin extends ReflectiveCordovaPlugin {
                             //only update if the caller of respondWithDynamicLink is getDynamicLink
                             //because if respondWithDynamicLink is being called from the onDynamicLink event, we do not want to update
                             //this is to prevent returning the same dynamic link in multiple calls to getDynamicLink
-                            if(callerMethod == 2){
+                            if(callerMethod == CALLER_GET_DYNAMIC_LINK){
                                 lastTimestamp = data.getClickTimestamp();
                             }
                             return result;

--- a/src/android/FirebaseDynamicLinksPlugin.java
+++ b/src/android/FirebaseDynamicLinksPlugin.java
@@ -34,6 +34,7 @@ public class FirebaseDynamicLinksPlugin extends ReflectiveCordovaPlugin {
     private FirebaseDynamicLinks firebaseDynamicLinks;
     private String domainUriPrefix;
     private CallbackContext dynamicLinkCallback;
+    private long lastTimestamp;
 
     @Override
     protected void pluginInitialize() {
@@ -41,18 +42,19 @@ public class FirebaseDynamicLinksPlugin extends ReflectiveCordovaPlugin {
 
         this.firebaseDynamicLinks = FirebaseDynamicLinks.getInstance();
         this.domainUriPrefix = this.preferences.getString("DOMAIN_URI_PREFIX", "");
+        this.lastTimestamp = 0;
     }
 
     @Override
     public void onNewIntent(Intent intent) {
         if (dynamicLinkCallback != null) {
-            respondWithDynamicLink(intent, dynamicLinkCallback);
+            respondWithDynamicLink(intent, dynamicLinkCallback, 1);
         }
     }
 
     @CordovaMethod
     private void getDynamicLink(CallbackContext callbackContext) {
-        respondWithDynamicLink(cordova.getActivity().getIntent(), callbackContext);
+        respondWithDynamicLink(cordova.getActivity().getIntent(), callbackContext, 2);
     }
 
     @CordovaMethod
@@ -80,25 +82,36 @@ public class FirebaseDynamicLinksPlugin extends ReflectiveCordovaPlugin {
         }
     }
 
-    private void respondWithDynamicLink(Intent intent, final CallbackContext callbackContext) {
+    private void respondWithDynamicLink(Intent intent, final CallbackContext callbackContext, int callerMethod) {
         this.firebaseDynamicLinks.getDynamicLink(intent)
                 .continueWith(new Continuation<PendingDynamicLinkData, JSONObject>() {
                     @Override
                     public JSONObject then(Task<PendingDynamicLinkData> task) throws JSONException {
                         PendingDynamicLinkData data = task.getResult();
 
-                        JSONObject result = new JSONObject();
-                        result.put("deepLink", data.getLink());
-                        result.put("clickTimestamp", data.getClickTimestamp());
-                        result.put("minimumAppVersion", data.getMinimumAppVersion());
+                        if(lastTimestamp != data.getClickTimestamp()){
+                            JSONObject result = new JSONObject();
+                            result.put("deepLink", data.getLink());
+                            result.put("clickTimestamp", data.getClickTimestamp());
+                            result.put("minimumAppVersion", data.getMinimumAppVersion());
 
-                        if (callbackContext != null) {
-                            PluginResult pluginResult = new PluginResult(PluginResult.Status.OK, result);
-                            pluginResult.setKeepCallback(callbackContext == dynamicLinkCallback);
-                            callbackContext.sendPluginResult(pluginResult);
+                            if (callbackContext != null) {
+                                PluginResult pluginResult = new PluginResult(PluginResult.Status.OK, result);
+                                pluginResult.setKeepCallback(callbackContext == dynamicLinkCallback);
+                                callbackContext.sendPluginResult(pluginResult);
+                            }
+                            //only update if the caller of respondWithDynamicLink is getDynamicLink
+                            //because if respondWithDynamicLink is being called from the onDynamicLink event, we do not want to update
+                            //this is to prevent returning the same dynamic link in multiple calls to getDynamicLink
+                            if(callerMethod == 2){
+                                lastTimestamp = data.getClickTimestamp();
+                            }
+                            return result;
                         }
-
-                        return result;
+                        else{
+                            callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.OK, (String)null));
+                            return null;
+                        }
                     }
                 })
                 .addOnFailureListener(new OnFailureListener() {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Changed Android implementation of respondWithDynamicLink() method to only deal with the same dynamic link once. Using the timestamp parameter of the dynamic link object (PendingDynamicLinkData), we can identify if a dynamic link was already dealt with, and only send a dynamic link as a result when it hasn't been dealt with.

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->

In Android, when calling the GetDynamicLink action from the wrapper more than once, we were getting multiple responses with the same dynamic link.

References: https://outsystemsrd.atlassian.net/browse/RMET-585

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android
- [ ] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->

Very thorough tests in Android device in emulator (Pixel 4 running Android 11).

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
