### PR TITLE
RMET-591 Firebase Dynamic Links - Use url to specify repository for analytics dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The changes documented here do not include those from the original repository.
 
 ## [Unreleased]
 
+## 2021-05-18
+- fix: Changed the dependency to our firebase analytics plugin to use the repository url.
+
 ## 2021-05-04
 - feat: added pipelines configuration (https://outsystemsrd.atlassian.net/browse/RMET-588)
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -21,7 +21,7 @@ xmlns:android="http://schemas.android.com/apk/res/android"
     <preference name="APP_DOMAIN_NAME" default="firebase_domain_url_prefix"/>
     <preference name="APP_DOMAIN_PATH" default="/" />
 
-    <dependency id="cordova-plugin-firebase-analytics" version="5.0.0-OS"/>
+    <dependency id="cordova-plugin-firebase-analytics" url="https://github.com/OutSystems/cordova-plugin-firebase-analytics.git#5.0.0-OS"/>
 
     <platform name="android">
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Changed the dependency to our firebase analytics plugin to use the repository url.

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->
Builds started failing because of this. MABS was trying to use the npm public registry to locate the plugin.

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android
- [x] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->
MABS builds working (6 and 7).

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
