### PR TITLE
RMET-732 Updated DynamicLinks plugin version on Android and iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The changes documented here do not include those from the original repository.
 
 ## [Unreleased]
 
+## 2021-08-24
+- Updated Firebase plugin versions to 8.6.0 on iOS and 20.1.+ on Android RMET-732
+
 ## [5.0.0-OS1]
 
 ## 2021-07-22

--- a/plugin.xml
+++ b/plugin.xml
@@ -55,7 +55,7 @@ xmlns:android="http://schemas.android.com/apk/res/android"
     </platform>
 
     <platform name="ios">
-        <preference name="IOS_FIREBASE_DYNAMICLINKS_VERSION" default="~> 8.4.0"/>
+        <preference name="IOS_FIREBASE_DYNAMICLINKS_VERSION" default="~> 8.6.0"/>
 
         <hook type="after_prepare" src="hooks/iOSCopyPreferences.js" />
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -27,7 +27,7 @@ xmlns:android="http://schemas.android.com/apk/res/android"
 
         <hook type="after_prepare" src="hooks/androidCopyPreferences.js" />
 
-        <preference name="ANDROID_FIREBASE_DYNAMICLINKS_VERSION" default="20.1.+"/>
+        <preference name="ANDROID_FIREBASE_DYNAMICLINKS_VERSION" default="19.1.+"/>
 
         <config-file parent="/*" target="res/xml/config.xml">
             <preference name="DOMAIN_URI_PREFIX" value="https://$APP_DOMAIN_NAME$APP_DOMAIN_PATH"/>

--- a/plugin.xml
+++ b/plugin.xml
@@ -104,7 +104,12 @@ xmlns:android="http://schemas.android.com/apk/res/android"
         <header-file src="src/ios/FirebaseDynamicLinksPlugin.h" />
         <source-file src="src/ios/FirebaseDynamicLinksPlugin.m" />
 
-         <framework src="Firebase/DynamicLinks" type="podspec" spec="~> 8.6.0"/>
+        <podspec>
+            <pods>
+                <pod name="Firebase/DynamicLinks"spec="~> 8.6.0" />
+            </pods>
+        </podspec>
+
     </platform>
 
 </plugin>

--- a/plugin.xml
+++ b/plugin.xml
@@ -104,7 +104,7 @@ xmlns:android="http://schemas.android.com/apk/res/android"
         <header-file src="src/ios/FirebaseDynamicLinksPlugin.h" />
         <source-file src="src/ios/FirebaseDynamicLinksPlugin.m" />
 
-         <framework src="Firebase/DynamicLinks" type="podspec" spec="~> 7.0.0"/>
+         <framework src="Firebase/DynamicLinks" type="podspec" spec="~> 8.6.0"/>
     </platform>
 
 </plugin>

--- a/plugin.xml
+++ b/plugin.xml
@@ -27,7 +27,7 @@ xmlns:android="http://schemas.android.com/apk/res/android"
 
         <hook type="after_prepare" src="hooks/androidCopyPreferences.js" />
 
-        <preference name="ANDROID_FIREBASE_DYNAMICLINKS_VERSION" default="19.1.+"/>
+        <preference name="ANDROID_FIREBASE_DYNAMICLINKS_VERSION" default="20.1.+"/>
 
         <config-file parent="/*" target="res/xml/config.xml">
             <preference name="DOMAIN_URI_PREFIX" value="https://$APP_DOMAIN_NAME$APP_DOMAIN_PATH"/>
@@ -106,7 +106,7 @@ xmlns:android="http://schemas.android.com/apk/res/android"
 
         <podspec>
             <pods>
-                <pod name="Firebase/DynamicLinks"spec="~> 8.6.0" />
+                <pod name="Firebase/DynamicLinks" spec="~> 8.6.0" />
             </pods>
         </podspec>
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -55,6 +55,7 @@ xmlns:android="http://schemas.android.com/apk/res/android"
     </platform>
 
     <platform name="ios">
+        <preference name="IOS_FIREBASE_DYNAMICLINKS_VERSION" default="~> 8.4.0"/>
 
         <hook type="after_prepare" src="hooks/iOSCopyPreferences.js" />
 
@@ -105,8 +106,11 @@ xmlns:android="http://schemas.android.com/apk/res/android"
         <source-file src="src/ios/FirebaseDynamicLinksPlugin.m" />
 
         <podspec>
+            <config>
+                <source url="https://cdn.cocoapods.org/" />
+            </config>
             <pods>
-                <pod name="Firebase/DynamicLinks" spec="~> 8.6.0" />
+                <pod name="Firebase/DynamicLinks" spec="$IOS_FIREBASE_DYNAMICLINKS_VERSION" />
             </pods>
         </podspec>
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -27,7 +27,7 @@ xmlns:android="http://schemas.android.com/apk/res/android"
 
         <hook type="after_prepare" src="hooks/androidCopyPreferences.js" />
 
-        <preference name="ANDROID_FIREBASE_DYNAMICLINKS_VERSION" default="19.1.+"/>
+        <preference name="ANDROID_FIREBASE_DYNAMICLINKS_VERSION" default="20.1.+"/>
 
         <config-file parent="/*" target="res/xml/config.xml">
             <preference name="DOMAIN_URI_PREFIX" value="https://$APP_DOMAIN_NAME$APP_DOMAIN_PATH"/>


### PR DESCRIPTION
## Description
Updated Firebase library version to 8.6.0 on iOS, and 20.1.+ on Android

## Context
The original issue was extended to upgrade Firebase/Crashlytics version. Because of this, we also needed to update the remaining Firebase plugins.
https://outsystemsrd.atlassian.net/browse/RMET-732

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [X] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [X] Android
- [X] iOS
- [ ] JavaScript

## Tests
Tested on MABS 7.1.

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [X] Pull request title follows the format `RNMT-XXXX <title>`
- [X] Code follows code style of this project
- [X] CHANGELOG.md file is correctly updated
- [X] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
