### PR TITLE
RNET-2442 - Update dependency fixed version

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -52,7 +52,7 @@ xmlns:android="http://schemas.android.com/apk/res/android"
         <!--<dependency id="cordova-support-android-plugin" version="~1.0.0"/>-->
         <!--<dependency id="cordova-support-google-services" version="^1.3.0"/>-->
 
-        <dependency id="cordova-support-android-plugin" version="~1.0.0"/>
+        <dependency id="cordova-support-android-plugin" version=">=1.0.0"/>
 
         <framework src="com.google.firebase:firebase-dynamic-links:$ANDROID_FIREBASE_DYNAMICLINKS_VERSION" />
     </platform>

--- a/src/android/FirebaseDynamicLinksPlugin.java
+++ b/src/android/FirebaseDynamicLinksPlugin.java
@@ -1,5 +1,6 @@
 package by.chemerisuk.cordova.firebase;
 
+import static by.chemerisuk.cordova.support.ExecutionThread.WORKER;
 import android.content.Intent;
 import android.net.Uri;
 import android.util.Log;


### PR DESCRIPTION
## Description
I changed the version of cordova-support-android-plugin to >=1.0.0 to adapt new version of that plugin

## Context
I am facing issue when generate the mobile with the Cordova plugin cordova-plugin-firebase-dynamiclinks, the issue is: Failed to install 'cordova-plugin-firebase-dynamiclinks': CordovaError: Version of installed plugin: "cordova-support-android-plugin@2.0.4" does not satisfy dependency plugin requirement "cordova-support-android-plugin@~1.0.0". Try --force to use installed plugin as dependency. So that I think change the version of cordova-support-android-plugin to >=1.0.0 can fix my issue.

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x ] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [ x] Android
- [ ] iOS
- [ ] JavaScript

## Screenshots (if appropriate)
![image](https://github.com/OutSystems/cordova-plugin-firebase-dynamiclinks/assets/7261775/b03be3e6-2980-4174-aa14-42ed461b3aa6)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [ x] Pull request title follows the format `RNMT-XXXX <title>`
- [x ] Code follows code style of this project
- [ x] CHANGELOG.md file is correctly updated
- [x ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
