### PR TITLE
RMET-3144 ::: iOS ::: Raise Pod Version to `8.15.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 The changes documented here do not include those from the original repository.
 
 ## [Unreleased]
+### 2024-01-31
+- Chore: Update Firebase/DynamicLinks pod to version 8.15.0. (https://outsystemsrd.atlassian.net/browse/RMET-3144)
 
 ## [5.0.0-OS10]
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -58,7 +58,7 @@ xmlns:android="http://schemas.android.com/apk/res/android"
     </platform>
 
     <platform name="ios">
-        <preference name="IOS_FIREBASE_DYNAMICLINKS_VERSION" default="~> 8.6.0"/>
+        <preference name="IOS_FIREBASE_DYNAMICLINKS_VERSION" default="8.15.0"/>
 
         <hook type="after_prepare" src="hooks/ios/iOSCopyPreferences.js" />
 


### PR DESCRIPTION
## Description
- Raises Pod version to `8.15.0`.

## Context
https://outsystemsrd.atlassian.net/browse/RMET-3144

## Type of changes
- [ ] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [x] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [ ] Android
- [x] iOS
- [ ] JavaScript

## Tests
Manual testing was performed.

## Checklist
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [ ] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
