### PR TITLE
RMET-3165 ::: Android ::: Update Gradle Dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 The changes documented here do not include those from the original repository.
 
 ## [Unreleased]
+
+### 2024-02-12
+- Fix: Update the `com.android.tools.build:gradle` and `com.google.gms:google-services` gradle dependencies (https://outsystemsrd.atlassian.net/browse/RMET-3165).
+
 ### 2024-01-31
 - Chore: Update Firebase/DynamicLinks pod to version 8.15.0. (https://outsystemsrd.atlassian.net/browse/RMET-3144)
 

--- a/hooks/android/build_gradle_add_dependency.js
+++ b/hooks/android/build_gradle_add_dependency.js
@@ -8,8 +8,8 @@ module.exports = function(ctx) {
 
 var googleServicesStr = "if (project.extensions.findByName('googleServices') == null) { apply plugin: 'com.google.gms.google-services' }"
 var googleServicesStrExists = false
-var classpathsStrToVerify = "com.google.gms:google-services:4.3.10"
-var classpathsStr = '\t\tclasspath "com.google.gms:google-services:4.3.10"'
+var classpathsStrToVerify = "com.google.gms:google-services:4.3.14"
+var classpathsStr = '\t\tclasspath "com.google.gms:google-services:4.3.14"'
 var rootBuildGradlePath = "platforms/android/build.gradle"
 var appBuildGradlePath = "platforms/android/app/build.gradle"
 

--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -5,8 +5,8 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.4.2'
-        classpath 'com.google.gms:google-services:4.2.0'
+        classpath 'com.android.tools.build:gradle:3.6.4'
+        classpath 'com.google.gms:google-services:4.3.14'
     }
 }
 


### PR DESCRIPTION
## Description
Update
- `com.android.tools.build:gradle` to 3.6.4 
- `com.google.gms:google-services` to 4.3.14

## Context
https://outsystemsrd.atlassian.net/browse/RMET-3165

## Type of changes
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android
- [ ] iOS
- [ ] JavaScript

## Tests
Manual testing was performed. There was the need to create a new app to test the issue as `Firebase Sample App` was not able to reproduce the issue. `RMET3164` is a clone of `Firebase Sample App` with only Dynamic Links included (all other plugins were removed).
As the following screenshot shows, the app is now compilable on both MABS 9 and 10.

![image](https://github.com/OutSystems/cordova-plugin-firebase-dynamiclinks/assets/97543217/fb916f3d-74f2-4d6b-a9c6-47c223303953)

## Checklist
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
