### PR TITLE
RMET-3274 ::: iOS ::: Update 3rd Party that Adds Privacy Manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,14 @@ The changes documented here do not include those from the original repository.
 
 ## [Unreleased]
 
+### 2024-03-21
+- Chore: Update `FirebaseDynamicLinks` iOS pod to version `10.23.0`. This includes the Privacy Manifest (https://outsystemsrd.atlassian.net/browse/RMET-3274).
+
 ### 2024-02-12
 - Fix: Update the `com.android.tools.build:gradle` and `com.google.gms:google-services` gradle dependencies (https://outsystemsrd.atlassian.net/browse/RMET-3165).
 
 ### 2024-01-31
-- Chore: Update Firebase/DynamicLinks pod to version 8.15.0. (https://outsystemsrd.atlassian.net/browse/RMET-3144)
+- Chore: Update `Firebase/DynamicLinks` iOS pod to version `8.15.0` (https://outsystemsrd.atlassian.net/browse/RMET-3144).
 
 ## [5.0.0-OS10]
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -58,7 +58,7 @@ xmlns:android="http://schemas.android.com/apk/res/android"
     </platform>
 
     <platform name="ios">
-        <preference name="IOS_FIREBASE_DYNAMICLINKS_VERSION" default="8.15.0"/>
+        <preference name="IOS_FIREBASE_DYNAMICLINKS_VERSION" default="10.23.0"/>
 
         <hook type="after_prepare" src="hooks/ios/iOSCopyPreferences.js" />
 
@@ -112,8 +112,8 @@ xmlns:android="http://schemas.android.com/apk/res/android"
             <config>
                 <source url="https://cdn.cocoapods.org/" />
             </config>
-            <pods>
-                <pod name="Firebase/DynamicLinks" spec="$IOS_FIREBASE_DYNAMICLINKS_VERSION" />
+            <pods use-frameworks="true">
+                <pod name="FirebaseDynamicLinks" spec="$IOS_FIREBASE_DYNAMICLINKS_VERSION" />
             </pods>
         </podspec>
 

--- a/src/ios/FirebaseDynamicLinksPlugin.h
+++ b/src/ios/FirebaseDynamicLinksPlugin.h
@@ -1,7 +1,7 @@
 #import <Cordova/CDV.h>
 #import "AppDelegate.h"
 
-@import Firebase;
+@import FirebaseDynamicLinks;
 
 @interface FirebaseDynamicLinksPlugin : CDVPlugin
 

--- a/src/ios/FirebaseDynamicLinksPlugin.m
+++ b/src/ios/FirebaseDynamicLinksPlugin.m
@@ -1,5 +1,7 @@
 #import "FirebaseDynamicLinksPlugin.h"
 
+@import FirebaseCore;
+
 @implementation FirebaseDynamicLinksPlugin
 
 - (void)pluginInitialize {


### PR DESCRIPTION
## Description
- Update 3rd party SDK version to `10.23.0`.
- Enable the `use_frameworks` flag for CocoaPods.
- Fix import errors.
- Replace the `FIRDynamicLinks`'s `dynamicLinkFromUniversalLinkURL:` method with a new implementation using `dynamicLinkFromUniversalLinkURL:completion:`. This to fix a deprecation warning.

## Context
https://outsystemsrd.atlassian.net/browse/RMET-3274

## Type of changes
- [ ] Fix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [x] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [ ] Android
- [x] iOS
- [ ] JavaScript

## Tests
Manual testing was performed and all were successful.

## Firebase Sample App Privacy Report
[Firebase.Sample.App-PrivacyReport.pdf](https://github.com/OutSystems/cordova-plugin-firebase-dynamiclinks/files/14703513/Firebase.Sample.App-PrivacyReport.pdf)

## Checklist
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
